### PR TITLE
fix: add macOS ARM64 native optional deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,10 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-darwin-arm64": "^4.3.3",
+        "lightningcss-darwin-arm64": "^1.32.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -8266,6 +8270,42 @@
     "packages/sync": {
       "name": "@flyx/sync",
       "version": "0.0.0"
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+      "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -76,5 +76,9 @@
   "dependencies": {
     "jose": "^6.2.4",
     "lucide-react": "^1.25.0"
+  },
+  "optionalDependencies": {
+    "@tailwindcss/oxide-darwin-arm64": "^4.3.3",
+    "lightningcss-darwin-arm64": "^1.32.0"
   }
 }


### PR DESCRIPTION
## Summary

Adds macOS Apple Silicon native optional dependencies required by the standalone Next.js build:

- `lightningcss-darwin-arm64`
- `@tailwindcss/oxide-darwin-arm64`

This fixes `flyx update` failing on macOS ARM64 when CSS tooling cannot resolve native Lightning CSS / Tailwind oxide bindings.

## Why this should not affect other platforms

Both native packages are optional dependencies and their lockfile entries are platform-gated:

- `os: ["darwin"]`
- `cpu: ["arm64"]`
- `optional: true`

Linux, Windows, and non-ARM macOS installs should skip these packages.

## Verification

Ran successfully on macOS ARM64:

```bash
node packages/cli/cli.js update --no-git
```

Result:

```text
✅ Build complete.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added optional support packages for Darwin ARM64 environments to improve compatibility with Tailwind CSS and Lightning CSS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->